### PR TITLE
replace ` in command to \`  for escape (#136)

### DIFF
--- a/plink-common/src/main/java/com/github/hairless/plink/common/builder/SqlJobBuilder.java
+++ b/plink-common/src/main/java/com/github/hairless/plink/common/builder/SqlJobBuilder.java
@@ -49,7 +49,7 @@ public class SqlJobBuilder implements JobBuilder {
         flinkConfig.setMainClass(PlinkSqlUtil.PLINK_SQL_JOB_DRIVER_CLASS_NAME);
         SqlConfig sqlConfig = new SqlConfig();
         sqlConfig.setJobName(jobName);
-        sqlConfig.setSql(jobInstanceDTO.getExtraConfig().get("sql").textValue());
+        sqlConfig.setSql(jobInstanceDTO.getExtraConfig().get("sql").textValue().replace("`", "\\`"));
         List<String> args = new ArrayList<>();
         args.add("\"-c\"");
         args.add('"' + StringEscapeUtils.escapeJava(JsonUtil.toJSONString(sqlConfig)) + '"');


### PR DESCRIPTION
* replace ` in command to \`  for escape

当sql语句中包含特殊字符需要转义时，加上`后启动任务失败

* fix sql build

* del SqlJobBuilderTest